### PR TITLE
Yaw api integration purchase template

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 NODE_ENV=development
+SERVER_BASE_URL=http://localhost:8080/api

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
 NODE_ENV=development
-SERVER_BASE_URL=http://localhost:8080/api
+REACT_APP_API_URL=http://localhost:8080/api

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import './App.less';
 import Header from '@module/layout/component/header/header';
 import AppSider from '@module/layout/component/sider/sider';
-import getMock from '@api/api-mocks.api';
+// import getMock from '@api/api-mocks.api';
 
 // Import the functions you need from the SDKs you need
 import { initializeApp } from 'firebase/app';
@@ -37,7 +37,7 @@ if (process.env.NODE_ENV === 'production') {
   getAnalytics(app);
 }
 if (process.env.NODE_ENV === 'development') {
-  getMock();
+  // getMock();
 }
 
 export interface IAppProps extends StateProps, DispatchProps {}

--- a/src/api/api-mocks.api.ts
+++ b/src/api/api-mocks.api.ts
@@ -362,7 +362,7 @@ mock.onGet(GET_COMPONENT_BY_SEARCH).reply<IPurchaseRequisitionTemplateItem[]>(20
 mock.onPost(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate>(200, {
   id: 1,
   templateName: 'template 1',
-  templateItems: [
+  purchaseRequisitionTemplateItemList: [
     {
       id: 1,
       sequence: 1,
@@ -407,7 +407,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'Kong Long HUAT CHEMICAL',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -504,7 +504,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -547,7 +547,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -590,7 +590,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -633,7 +633,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -676,7 +676,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -719,7 +719,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -762,7 +762,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -805,7 +805,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,
@@ -848,7 +848,7 @@ mock.onGet(PURCHASE_REQUISITION_TEMPLATE).reply<IPurchaseRequisitionTemplate[]>(
   {
     id: 1,
     templateName: 'template 1',
-    templateItems: [
+    purchaseRequisitionTemplateItemList: [
       {
         id: 1,
         sequence: 1,

--- a/src/api/purchase-order.api.ts
+++ b/src/api/purchase-order.api.ts
@@ -9,8 +9,16 @@ export async function createPurchaseOrder(purchaseOrder: IPurchaseOrder) {
   return await axios.post<IPurchaseApprovalOrder>(PURCHASE_ORDER, purchaseOrder);
 }
 
+export async function issuePO(purchaseApprovalId: number) {
+  return await axios.post<IPurchaseApprovalOrder>(`${PURCHASE_ORDER}/${purchaseApprovalId}`);
+}
+
 export async function getPurchaseOrders(startDate: Date, endDate: Date, sortBy: Sort) {
   const wrappedParams = { startDate, endDate, sortBy };
   const url: string = QueryParamsBuilder.withUrl(PURCHASE_ORDER).addParams(wrappedParams).build();
   return await axios.get<IPurchaseApprovalOrder[]>(url);
+}
+
+export async function emailPurchaseOrder(purchaseApprovalId: number) {
+  return await axios.post<void>(`${PURCHASE_ORDER}/email/${purchaseApprovalId}`);
 }

--- a/src/api/purchase-requisition-approval.api.ts
+++ b/src/api/purchase-requisition-approval.api.ts
@@ -1,7 +1,11 @@
-import axios from 'axios';
 import { PURCHASE_REQUISITION_APPROVAL } from '@constant/api-endpoints';
 import { IPurchaseRequisitionApproval } from '@dto/i-purchase-requisition-approval.dto';
+import { QueryParamsBuilder } from '@utils/api/query-params-builder';
+import axios from 'axios';
 
 export async function getPurchaseRequisitionApproval() {
-  return await axios.get<IPurchaseRequisitionApproval[]>(PURCHASE_REQUISITION_APPROVAL);
+  let sort = 'createdDate,desc';
+  const wrappedParams = { sort };
+  const url: string = QueryParamsBuilder.withUrl(`${PURCHASE_REQUISITION_APPROVAL}`).addParams(wrappedParams).build();
+  return await axios.get<IPurchaseRequisitionApproval[]>(url);
 }

--- a/src/api/purchase-requisition-request.api.ts
+++ b/src/api/purchase-requisition-request.api.ts
@@ -9,7 +9,15 @@ export async function createPurchaseRequisitionRequest(purchaseRequisitionReques
 }
 
 export async function getPurchaseRequisitionRequest(startDate: Date, endDate: Date, sortBy: Sort) {
-  const wrappedParams = { startDate, endDate, sortBy };
-  const url: string = QueryParamsBuilder.withUrl(PURCHASE_REQUISITION_REQUEST).addParams(wrappedParams).build();
+  // TODO: Temporary remove filter date parameter
+  // const wrappedParams = { startDate, endDate, sortBy };
+  let sort = 'createdDate';
+  if (sortBy === Sort.DES) {
+    sort += ',desc';
+  } else if (sortBy === Sort.ASC) {
+    sort += ',asc';
+  }
+  const wrappedParams = { sort };
+  const url: string = QueryParamsBuilder.withUrl(`${PURCHASE_REQUISITION_REQUEST}/submission`).addParams(wrappedParams).build();
   return await axios.get<IPurchaseRequisitionRequest[]>(url);
 }

--- a/src/api/purchase-requisition-request.api.ts
+++ b/src/api/purchase-requisition-request.api.ts
@@ -5,7 +5,7 @@ import { QueryParamsBuilder } from '@utils/api/query-params-builder';
 import { PURCHASE_REQUISITION_REQUEST } from '@constant/api-endpoints';
 
 export async function createPurchaseRequisitionRequest(purchaseRequisitionRequest: IPurchaseRequisitionRequest) {
-  return await axios.post<IPurchaseRequisitionRequest>(PURCHASE_REQUISITION_REQUEST, purchaseRequisitionRequest);
+  return await axios.post<IPurchaseRequisitionRequest>(`${PURCHASE_REQUISITION_REQUEST}/request`, purchaseRequisitionRequest);
 }
 
 export async function getPurchaseRequisitionRequest(startDate: Date, endDate: Date, sortBy: Sort) {

--- a/src/api/purchase-requisition-template.api.ts
+++ b/src/api/purchase-requisition-template.api.ts
@@ -1,15 +1,22 @@
 import axios from 'axios';
-import { IPurchaseRequisitionRequest } from '@dto/i-purchase-requisition-request.dto';
 import { IPurchaseRequisitionTemplate } from '@dto/i-purchase-requisition-template.dto';
 import { COMPONENT, PURCHASE_REQUISITION_TEMPLATE } from '@constant/api-endpoints';
 import { IPurchaseRequisitionTemplateItem } from '@dto/i-purchase-requisition-template-item.dto';
 
-export async function createPurchaseReqiosition(purchaseRequisitionRequest: IPurchaseRequisitionRequest) {
-  return await axios.post<IPurchaseRequisitionTemplate>(PURCHASE_REQUISITION_TEMPLATE, purchaseRequisitionRequest);
+export async function createPurchaseRequisitionTemplate(purchaseRequisitionTemplate: IPurchaseRequisitionTemplate) {
+  return await axios.post<IPurchaseRequisitionTemplate>(PURCHASE_REQUISITION_TEMPLATE, purchaseRequisitionTemplate);
+}
+
+export async function updatePurchaseRequisitionTemplate(purchaseRequisitionTemplate: IPurchaseRequisitionTemplate) {
+  return await axios.put<IPurchaseRequisitionTemplate>(`${PURCHASE_REQUISITION_TEMPLATE}/${purchaseRequisitionTemplate.id}`, purchaseRequisitionTemplate);
 }
 
 export async function getPurchaseRequisitionTemplate() {
   return await axios.get<IPurchaseRequisitionTemplate[]>(PURCHASE_REQUISITION_TEMPLATE);
+}
+
+export async function deletePurchaseRequisitionTemplate(purchaseRequisitionTemplateId: number) {
+  return await axios.delete<IPurchaseRequisitionTemplate>(`${PURCHASE_REQUISITION_TEMPLATE}/${purchaseRequisitionTemplateId}`);
 }
 
 export async function getItemBySearch(component: string, vendor: string, packingSize?: number) {

--- a/src/constant/api-endpoints.ts
+++ b/src/constant/api-endpoints.ts
@@ -1,5 +1,5 @@
-export const PURCHASE_REQUISITION_TEMPLATE: string = 'purchase-requisition/template';
-export const PURCHASE_REQUISITION_REQUEST: string = 'purchase-requisition/request';
+export const PURCHASE_REQUISITION_TEMPLATE: string = 'purchase-template';
+export const PURCHASE_REQUISITION_REQUEST: string = 'purchase-requisition';
 export const PURCHASE_REQUISITION_APPROVAL: string = 'purchase-requisition/approval';
 export const PURCHASE_ORDER: string = 'purchase-order';
 export const PURCHASE_REQUISITION_REQUEST_REGEX: RegExp = new RegExp(`${PURCHASE_REQUISITION_REQUEST}*`);

--- a/src/constant/purchase-requisition-approval-status.enum.ts
+++ b/src/constant/purchase-requisition-approval-status.enum.ts
@@ -4,13 +4,17 @@ export enum PurchaseRequisitionApprovalStatus {
   ISSUED,
 }
 
-const DISPLAY_TEXT_MAP = new Map<PurchaseRequisitionApprovalStatus, string>();
-DISPLAY_TEXT_MAP.set(PurchaseRequisitionApprovalStatus.TO_CONFIRM, 'To be confirmed');
-DISPLAY_TEXT_MAP.set(PurchaseRequisitionApprovalStatus.CONFIRMED, 'Confirmed');
-DISPLAY_TEXT_MAP.set(PurchaseRequisitionApprovalStatus.ISSUED, 'Issued');
+const DISPLAY_TEXT_MAP = new Map<string, string>();
+DISPLAY_TEXT_MAP.set(PurchaseRequisitionApprovalStatus[PurchaseRequisitionApprovalStatus.TO_CONFIRM], 'To be confirmed');
+DISPLAY_TEXT_MAP.set(PurchaseRequisitionApprovalStatus[PurchaseRequisitionApprovalStatus.CONFIRMED], 'Confirmed');
+DISPLAY_TEXT_MAP.set(PurchaseRequisitionApprovalStatus[PurchaseRequisitionApprovalStatus.ISSUED], 'Issued');
 
 export function PurchaseRequisitionApprovalStatusDisplayText(key: PurchaseRequisitionApprovalStatus): string {
-  const displayText = DISPLAY_TEXT_MAP.get(key);
+  console.log(key.toString());
+  console.log(PurchaseRequisitionApprovalStatus.CONFIRMED);
+  console.log(PurchaseRequisitionApprovalStatus.CONFIRMED.toString());
+  console.log(DISPLAY_TEXT_MAP);
+  const displayText = DISPLAY_TEXT_MAP.get(key.toString());
 
   if (displayText) {
     return displayText;

--- a/src/dto/i-purchase-requisition-template.dto.ts
+++ b/src/dto/i-purchase-requisition-template.dto.ts
@@ -3,6 +3,6 @@ import { IPurchaseRequisitionTemplateItem } from './i-purchase-requisition-templ
 export interface IPurchaseRequisitionTemplate {
   id: number;
   templateName: string;
-  templateItems: IPurchaseRequisitionTemplateItem[];
+  purchaseRequisitionTemplateItemList: IPurchaseRequisitionTemplateItem[];
   remarks: string;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,11 @@ import reportWebVitals from './reportWebVitals';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { Provider } from 'react-redux';
 import store from '@module/config/store';
+import axios from 'axios';
+
+const TIMEOUT = 1 * 60 * 1000;
+axios.defaults.timeout = TIMEOUT;
+axios.defaults.baseURL = process.env.SERVER_BASE_URL;
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,10 +7,30 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import { Provider } from 'react-redux';
 import store from '@module/config/store';
 import axios from 'axios';
+import 'dotenv/config';
+import { setLoading } from '@module/shared/reducers/app-reducers';
 
+// TODO: Temporary Axios Setting
 const TIMEOUT = 1 * 60 * 1000;
 axios.defaults.timeout = TIMEOUT;
-axios.defaults.baseURL = process.env.SERVER_BASE_URL;
+axios.defaults.baseURL = process.env.REACT_APP_API_URL;
+axios.interceptors.request.use(
+  (req) => {
+    setLoading(true);
+    return req;
+  }
+);
+axios.interceptors.response.use(
+  (res) => {
+    setLoading(false);
+    return res;
+  },
+  (err) => {
+    setLoading(false);
+    return Promise.reject(err);
+  }
+);
+// End Temporary Axios Setting
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/modules/purchase-order/components/purchase-order-table.tsx
+++ b/src/modules/purchase-order/components/purchase-order-table.tsx
@@ -99,7 +99,7 @@ const PurchaseOrderTable: React.FC<IPurchaseOrderTableProps> = (props) => {
       .catch(error => {
         console.log(error.response);
         const errResponse = error.response;
-        const errorMessage = errResponse.data ?? 'Request Failed';
+        const errorMessage = errResponse.data ? errResponse.data : 'Request Failed';
         popNotification(errorMessage, NotificationType.error);
       })
   };

--- a/src/modules/purchase-order/components/purchase-order-table.tsx
+++ b/src/modules/purchase-order/components/purchase-order-table.tsx
@@ -91,13 +91,11 @@ const PurchaseOrderTable: React.FC<IPurchaseOrderTableProps> = (props) => {
     console.groupEnd();
     emailPurchaseOrder(purchaseOrder.id)
       .then(res => {
-        console.log(res.status)
         if (res.status === 200) {
           popNotification('Success Email PO to vendor', NotificationType.success);
         }
       })
       .catch(error => {
-        console.log(error.response);
         const errResponse = error.response;
         const errorMessage = errResponse.data ? errResponse.data : 'Request Failed';
         popNotification(errorMessage, NotificationType.error);

--- a/src/modules/purchase-order/components/purchase-order-table.tsx
+++ b/src/modules/purchase-order/components/purchase-order-table.tsx
@@ -6,6 +6,9 @@ import { DownloadOutlined, MailOutlined } from '@ant-design/icons';
 import { TABLE_PAGINATION_CONFIG } from '@constant/pagination-config';
 import { IPurchaseOrder } from '@dto/i-purchase-order.dto';
 import { IPurchaseApprovalOrder } from '@dto/i-purchase-approval-order.dto';
+import { emailPurchaseOrder } from '@api/purchase-order.api';
+import { NotificationType } from '@constant/notification.enum';
+import { popNotification } from '@module/shared/components/notification';
 
 interface IPurchaseOrderTableProps {
   readonly currentPurchaseApprovalOrderRecord?: IPurchaseApprovalOrder;
@@ -86,6 +89,19 @@ const PurchaseOrderTable: React.FC<IPurchaseOrderTableProps> = (props) => {
     console.log('Email PO');
     console.log('Purchase Order: ', purchaseOrder);
     console.groupEnd();
+    emailPurchaseOrder(purchaseOrder.id)
+      .then(res => {
+        console.log(res.status)
+        if (res.status === 200) {
+          popNotification('Success Email PO to vendor', NotificationType.success);
+        }
+      })
+      .catch(error => {
+        console.log(error.response);
+        const errResponse = error.response;
+        const errorMessage = errResponse.data ?? 'Request Failed';
+        popNotification(errorMessage, NotificationType.error);
+      })
   };
 
   const emailAllPO = () => {

--- a/src/modules/purchase-requisition-approval/pages/purchase-requisition-approval-page.tsx
+++ b/src/modules/purchase-requisition-approval/pages/purchase-requisition-approval-page.tsx
@@ -147,7 +147,7 @@ const PurchaseRequisitionApprovalPage: React.FC<IPurchaseRequisitionApprovalProp
         .catch(error => {
           console.log(error.response);
           const errResponse = error.response;
-          const errorMessage = errResponse.data ?? 'Request Failed';
+          const errorMessage = errResponse.data ? errResponse.data : 'Request Failed';
           popNotification(errorMessage, NotificationType.error);
         })
     }

--- a/src/modules/purchase-requisition-request/components/request-constructor/request-constructor.tsx
+++ b/src/modules/purchase-requisition-request/components/request-constructor/request-constructor.tsx
@@ -50,7 +50,7 @@ const PurchaseRequisitionRequestConstructor: React.FC<IPurchaseRequisitionReques
     if (props.currentTemplate) {
       const updatedPurchaseRequisitionTemplate = CLONING_LIB.deepClone(props.currentTemplate);
       if (value) {
-        updatedPurchaseRequisitionTemplate.templateItems.forEach((item) => {
+        updatedPurchaseRequisitionTemplate.purchaseRequisitionTemplateItemList.forEach((item) => {
           item.deliveryDate = (value as Moment).toDate();
         });
         updateTemplate(updatedPurchaseRequisitionTemplate);
@@ -61,7 +61,7 @@ const PurchaseRequisitionRequestConstructor: React.FC<IPurchaseRequisitionReques
   const clearAllInput: () => void = () => {
     if (props.currentTemplate) {
       const updatedPurchaseRequisitionTemplate = CLONING_LIB.deepClone(props.currentTemplate);
-      updatedPurchaseRequisitionTemplate.templateItems.forEach((item) => {
+      updatedPurchaseRequisitionTemplate.purchaseRequisitionTemplateItemList.forEach((item) => {
         item.quantity = 0;
         item.packagingSize = 0;
         item.deliveryDate = undefined;
@@ -77,21 +77,21 @@ const PurchaseRequisitionRequestConstructor: React.FC<IPurchaseRequisitionReques
     key
   ) => {
     const idToUpdate = record.id;
-    const updatedSelectedPurchaseRequisitionApprovalItems = selectedPurchaseRequisitionApproval.templateItems.map((item) => {
+    const updatedSelectedPurchaseRequisitionApprovalItems = selectedPurchaseRequisitionApproval.purchaseRequisitionTemplateItemList.map((item) => {
       if (item.id === idToUpdate) {
         (item as any)[key] = value;
       }
       return item;
     });
     const updatedSelectedPurchaseRequisitionApproval = CLONING_LIB.deepClone(selectedPurchaseRequisitionApproval);
-    updatedSelectedPurchaseRequisitionApproval.templateItems = updatedSelectedPurchaseRequisitionApprovalItems;
+    updatedSelectedPurchaseRequisitionApproval.purchaseRequisitionTemplateItemList = updatedSelectedPurchaseRequisitionApprovalItems;
     return updatedSelectedPurchaseRequisitionApproval;
   };
 
   const clearInputByItemId: (record: IPurchaseRequisitionTemplateItem) => void = (record) => {
     if (props.currentTemplate) {
       const updatedPurchaseRequisitionTemplate = CLONING_LIB.deepClone(props.currentTemplate);
-      const updatedPurchaseRequisitionTemplateItems: IPurchaseRequisitionTemplateItem[] = updatedPurchaseRequisitionTemplate.templateItems.map((item) => {
+      const updatedPurchaseRequisitionTemplateItems: IPurchaseRequisitionTemplateItem[] = updatedPurchaseRequisitionTemplate.purchaseRequisitionTemplateItemList.map((item) => {
         if (item.id === record.id) {
           return {
             ...item,
@@ -103,7 +103,7 @@ const PurchaseRequisitionRequestConstructor: React.FC<IPurchaseRequisitionReques
           return item;
         }
       });
-      updatedPurchaseRequisitionTemplate.templateItems = updatedPurchaseRequisitionTemplateItems;
+      updatedPurchaseRequisitionTemplate.purchaseRequisitionTemplateItemList = updatedPurchaseRequisitionTemplateItems;
       updateTemplate(updatedPurchaseRequisitionTemplate);
     }
   };

--- a/src/modules/purchase-requisition-request/pages/purchase-requisition-request-page.tsx
+++ b/src/modules/purchase-requisition-request/pages/purchase-requisition-request-page.tsx
@@ -53,7 +53,7 @@ const PurchaseRequisitionRequestPage: React.FC<IPurchaseRequisitionRequestPagePr
 
   useEffect(() => {
     if (selectedTemplate) {
-      const initSearchResult = CLONING_LIB.deepClone(selectedTemplate.templateItems);
+      const initSearchResult = CLONING_LIB.deepClone(selectedTemplate.purchaseRequisitionTemplateItemList);
       setSearchResult(initSearchResult);
     }
   }, [selectedTemplate]);
@@ -74,7 +74,7 @@ const PurchaseRequisitionRequestPage: React.FC<IPurchaseRequisitionRequestPagePr
     if (selectedTemplate) {
       console.log('selectedPurchaseRequisitionApproval >>: ', selectedTemplate);
       const sanitisedSearchText: string = getSearchText(value);
-      const searchOutput = searchEngine.updateEngine(selectedTemplate.templateItems).search(sanitisedSearchText);
+      const searchOutput = searchEngine.updateEngine(selectedTemplate.purchaseRequisitionTemplateItemList).search(sanitisedSearchText);
       setSearchResult(searchOutput);
     }
     setTimeout(function () {

--- a/src/modules/purchase-requisition-request/pages/purchase-requisition-request-page.tsx
+++ b/src/modules/purchase-requisition-request/pages/purchase-requisition-request-page.tsx
@@ -20,6 +20,10 @@ import { APP_HEADER_HEIGHT } from '@constant/display/header.constant';
 import DEFAULT_PURCHASE_REQUISITION_REQUEST_TABLE_DISPLAY_SETTINGS from '@constant/purchase-requisition-request/purchase-requisition-request-table-display-settings';
 import { APP_CONTENT_MARGIN } from '@constant/display/content.constant';
 import { PURCHASE_REQUISITION_BOTTOM_TOOLS_HEIGHT, PURCHASE_REQUISITION_TITLE_HEIGHT, PURCHASE_REQUISITION_TOP_TOOLS_HEIGHT } from '@constant/display/purchase-requisition-request.constant';
+import { IPurchaseRequisitionRequest } from '@dto/i-purchase-requisition-request.dto';
+import { createPurchaseRequisitionRequest } from '@api/purchase-requisition-request.api';
+import { popNotification } from '@module/shared/components/notification';
+import { NotificationType } from '@constant/notification.enum';
 
 interface IPurchaseRequisitionRequestPageProps extends StateProps, DispatchProps {}
 
@@ -87,6 +91,28 @@ const PurchaseRequisitionRequestPage: React.FC<IPurchaseRequisitionRequestPagePr
     setShowTableDisplaySettings(!showTableDisplaySettings);
   };
 
+  const submitPurchaseRequest = () => {
+    const purchaseRequest: IPurchaseRequisitionRequest = {
+      remarks: selectedTemplate?.remarks ?? '',
+      templateId: selectedTemplate?.id ?? 0,
+      purchaseRequisitionRequestItems: [],
+      createdDate: new Date(),
+      id: 0
+    }
+    // TODO: Items List
+    // purchaseRequisitionRequestItems: selectedTemplate?.purchaseRequisitionTemplateItemList
+    createPurchaseRequisitionRequest(purchaseRequest)
+      .then(() => {
+        popNotification('Success Update Template', NotificationType.success);
+        setSelectedTemplate(undefined);
+      })
+      .catch(error => {
+        const errResponse = error.response;
+        const errorMessage = errResponse.data ? errResponse.data : 'Request Failed';
+        popNotification(errorMessage, NotificationType.error);
+      });
+  }
+
   return (
     <>
       <div className="container-fluid">
@@ -127,7 +153,7 @@ const PurchaseRequisitionRequestPage: React.FC<IPurchaseRequisitionRequestPagePr
             <Input.TextArea className="remarks-textbox" value={selectedTemplate?.remarks} onChange={updateRemarks} rows={3} placeholder="Remarks here"></Input.TextArea>
           </div>
           <div className="col d-flex flex-column align-items-end">
-            <Button type="primary" size="large">
+            <Button type="primary" size="large" onClick={submitPurchaseRequest}>
               Submit Request
             </Button>
           </div>

--- a/src/modules/purchase-requisition-submissioin-record/pages/purchase-requisition-submission-page.tsx
+++ b/src/modules/purchase-requisition-submissioin-record/pages/purchase-requisition-submission-page.tsx
@@ -38,7 +38,7 @@ const PurchaseRequisitionSubmissionPage: React.FC<IPurchaseRequisitionSubmission
 
   useEffect(() => {
     const getSubmissions = async () => {
-      const apiResponse = await getPurchaseRequisitionRequest(new Date(), new Date(), Sort.ASC);
+      const apiResponse = await getPurchaseRequisitionRequest(new Date('2021-12-17T03:24:00'), new Date(), Sort.DES);
 
       if (apiResponse && apiResponse.status === ApiResponseStatus.SUCCESS) {
         setPurchaseRequisitionSubmissions(apiResponse.data);

--- a/src/modules/purchase-requisition-template/components/template-browser.tsx
+++ b/src/modules/purchase-requisition-template/components/template-browser.tsx
@@ -1,7 +1,7 @@
 import { deletePurchaseRequisitionTemplate, getPurchaseRequisitionTemplate } from '@api/purchase-requisition-template.api';
 import { ApiResponseStatus } from '@constant/api-status.enum';
 import { IPurchaseRequisitionTemplate } from '@dto/i-purchase-requisition-template.dto';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button, Input, Row, Col, Modal } from 'antd';
 import Text from 'antd/lib/typography/Text';
 import { DeleteOutlined, ExclamationCircleOutlined } from '@ant-design/icons';

--- a/src/modules/purchase-requisition-template/components/template-table.tsx
+++ b/src/modules/purchase-requisition-template/components/template-table.tsx
@@ -83,7 +83,7 @@ const PurchaseRequisitionTemplateTable: React.FC<IPurchaseRequisitionTemplateTab
     },
   ];
 
-  const templateItems = props.filteredItems === undefined ? (props.currentTemplate?.templateItems ?? []) : props.filteredItems;
+  const templateItems = props.filteredItems === undefined ? (props.currentTemplate?.purchaseRequisitionTemplateItemList ?? []) : props.filteredItems;
   return (
     <>
       <Table className="my-4" style={{ width: "940px", maxWidth: "1000px" }} dataSource={templateItems} columns={PURCHASE_REQUISITION_TEMPLATE_TABLE_COLUMN} rowKey="sequence" scroll={{ y: 'calc(100vh - 250px)' }} pagination={TABLE_PAGINATION_CONFIG}></Table>


### PR DESCRIPTION
Pre-requisite: https://github.com/Five-Fishes/Engseen-Purchase-Requisition-Frontend/pull/95
- Purchase Template API Integration
    - Listing [Items not return from BE]
    - Create
    - Delete
    - Update [Get Failed Response from BE]
- Purchase Requisition Request
    - Create [Missing Logic to get Request Body from Table with Input]